### PR TITLE
Add a namespace for window events

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,17 +7,23 @@ type EffectCallbackWithParameters = (data: DataEffectParameters) => void;
 type DependencyList = string[];
 type UseEffectReturn = ReturnType<typeof useEffect>;
 
+const eventsNamespace = "useStorageListener_";
+
+const keyBuilder = (key: string) => {
+  return `${eventsNamespace}${key}`;
+}
+
 const useEffectStorageListener = (
   callback: EffectCallback | EffectCallbackWithParameters,
   dependencies: DependencyList
 ): UseEffectReturn => {
   useEffect(() => {
     dependencies.forEach((key: string) => {
-      window.addEventListener(key, storageWatcher);
+      window.addEventListener(keyBuilder(key), storageWatcher);
     });
     return () => {
       dependencies.forEach((key: string) => {
-        window.removeEventListener(key, storageWatcher);
+        window.removeEventListener(keyBuilder(key), storageWatcher);
       });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -57,9 +63,9 @@ export const useLocalStorage = (key: string) => {
   };
 
   useEffect(() => {
-    window.addEventListener(key, storageWatcher);
+    window.addEventListener(keyBuilder(key), storageWatcher);
     return () => {
-      window.removeEventListener(key, storageWatcher);
+      window.removeEventListener(keyBuilder(key), storageWatcher);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -73,7 +79,7 @@ export const useLocalStorage = (key: string) => {
  */
 const eventDispatcher = (key: string) => {
   return window.dispatchEvent(
-    new Event(key, { bubbles: true, cancelable: true })
+    new Event(keyBuilder(key), { bubbles: true, cancelable: true })
   );
 };
 


### PR DESCRIPTION
This PR adds a namespace for events when they are added to the windows object in order to avoid undesired behaviors in case a key is defined as a known event type (https://developer.mozilla.org/en-US/docs/Web/Events) e.g. "click", "scroll", "keydown", "beforeunload", etc.

before:
```js
// In component
const {state, setState} = useLocalStorage("click");

// It will result in
window.addEventListener("click", handler)
```
after:
```js
// In component
const {state, setState} = useLocalStorage("click");

// It will result in
window.addEventListener("useStorageListener_click", handler)
```

This PR doesn't modify the keys when they are added to the local storage.