### PR TITLE
Adding prefix to save the values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# Installation
+# useStorageListener 👨🏾‍🎤👩🏾‍🎤🧑🏾‍🎤
 
-###### `(i) new namespace for events 1.0.7`
+## Installation
+Sometimes we need to be able to detect changes in our localSotrage independently from the .* file we have made the modification, useStorageListener provides a dynamic way to listen for keys that are modified in the local storage in a simple and fast way, either using the listener effect or the state handler. 
+
+> note: The listener effect can listen to other events that are not related to the localStorage, simply specify the name of the event to listen to 🧐
+
+###### `(i) new auto type transformation 1.0.8` 🧩
 ----------
-### Using npm:
+### Using npm or yarn:
 
-`$ npm i use-storage-listener`
+```js script 
+$ npm i use-storage-listener
+$ yarn add use-storage-listener
+
+```
 
 ### Simple use - useStorageListener:
 ```js script
@@ -61,7 +70,7 @@ function Test() {
 
 | Option        | Params                                   | Description  |
 | ------------- |:----------------------------------------:| ------------:|
-| setStorage    | **key:** string  **arg:** string         | when it receives a key and a value, it will add these to the store, or update the value if the key already exists **(triggers useStorageListener)**|
+| setStorage    | **key:** string  **arg:** any         | when it receives a key and a value, it will add these to the store, or update the value if the key already exists **(triggers useStorageListener)**|
 | removeStorage | **key:** string                          | deletes the key whose name it receives as a parameter from storage **(triggers useStorageListener)**     |
 | getStorage    | **key:** string                          | when passed a key name, will return that key's value, or null if the key does not exist, in the given Storage object |
 | clearStorage  | **callEventKey?:** string                | deletes the key whose name it receives as a parameter from storage  **(Activates useStorageListener** if callEventKey is provided**)**   |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Sometimes we need to be able to detect changes in our localSotrage independently
 
 > note: The listener effect can listen to other events that are not related to the localStorage, simply specify the name of the event to listen to 🧐
 
-###### `(i) new auto type transformation 1.0.8` 🧩
+###### `(i) new auto type transformation 1.1.0` 🧩
 ----------
 ### Using npm or yarn:
 

--- a/lib/cjs/index.d.ts
+++ b/lib/cjs/index.d.ts
@@ -10,8 +10,8 @@ declare type DependencyList = string[];
 declare type UseEffectReturn = ReturnType<typeof useEffect>;
 declare const useEffectStorageListener: (callback: EffectCallback | EffectCallbackWithParameters, dependencies: DependencyList) => UseEffectReturn;
 export declare const useLocalStorage: (key: string) => {
-    state: string | null;
-    setState: import("react").Dispatch<import("react").SetStateAction<string | null>>;
+    state: any;
+    setState: import("react").Dispatch<any>;
 };
 /**
  * @param key

--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -2,9 +2,18 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.clearStorage = exports.getStorage = exports.removeStorage = exports.setStorage = exports.useLocalStorage = void 0;
 var react_1 = require("react");
+var StoreTypes;
+(function (StoreTypes) {
+    StoreTypes["primitive"] = "usl_primitive";
+    StoreTypes["object"] = "usl_object";
+    StoreTypes["undefined"] = "usl_undefined";
+})(StoreTypes || (StoreTypes = {}));
 var eventsNamespace = "useStorageListener_";
 var keyBuilder = function (key) {
     return "" + eventsNamespace + key;
+};
+var removeKeyBuilder = function (key) {
+    return key.replace(eventsNamespace, "");
 };
 var useEffectStorageListener = function (callback, dependencies) {
     react_1.useEffect(function () {
@@ -19,7 +28,7 @@ var useEffectStorageListener = function (callback, dependencies) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     var storageWatcher = function (e) {
-        callback({ key: e.type, value: exports.getStorage(e.type) });
+        callback({ key: removeKeyBuilder(e.type), value: exports.getStorage(e.type) });
     };
 };
 var useLocalStorage = function (key) {
@@ -64,18 +73,68 @@ exports.useLocalStorage = useLocalStorage;
 var eventDispatcher = function (key) {
     return window.dispatchEvent(new Event(keyBuilder(key), { bubbles: true, cancelable: true }));
 };
+/**
+ * @param value
+ * @returns
+ */
+var isPrimitive = function (value) {
+    return value == null || /^[sbn]/.test(typeof value);
+};
+/**
+ * @param value
+ * @returns
+ */
+var detectValueType = function (value) {
+    if (!value)
+        return StoreTypes.undefined;
+    if (isPrimitive(value)) {
+        return StoreTypes.primitive;
+    }
+    if (Array.isArray(value) || typeof value === "object") {
+        return StoreTypes.object;
+    }
+    return StoreTypes.undefined;
+};
+/**
+ * @param type
+ * @param value
+ * @returns
+ */
+var prefixBuilder = function (type, value) {
+    return value + "?" + eventsNamespace + "type=" + type;
+};
+/**
+ * @param value
+ * @returns
+ */
+var parseValueToSetStorage = function (value) {
+    var type = detectValueType(value);
+    if (type === StoreTypes.undefined)
+        return null;
+    var parseValue = type === StoreTypes.object ? JSON.stringify(value) : value;
+    return prefixBuilder(type, parseValue);
+};
+var parseValueToGetStorage = function (value) {
+    var nonParseData = value.split("?useStorageListener_type=");
+    switch (nonParseData[1]) {
+        case StoreTypes.object:
+            return JSON.parse(nonParseData[0]);
+        default:
+            return nonParseData[0];
+    }
+};
 // Local storage methods
 /**
  * @param key
  * @param arg
  */
 var setStorage = function (key, arg) {
+    var value = parseValueToSetStorage(arg);
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    if (!arg)
-        throw new Error("The storage events should not be used with no arguments");
-    var value = typeof arg === "string" ? arg : JSON.stringify(arg);
-    localStorage.setItem(key, value);
+    if (!value)
+        throw new Error("The storage events should not be used with null, undefined or no arguments ");
+    localStorage.setItem(removeKeyBuilder(key), value);
     eventDispatcher(key);
 };
 exports.setStorage = setStorage;
@@ -85,7 +144,7 @@ exports.setStorage = setStorage;
 var removeStorage = function (key) {
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    localStorage.removeItem(key);
+    localStorage.removeItem(removeKeyBuilder(key));
     eventDispatcher(key);
 };
 exports.removeStorage = removeStorage;
@@ -96,7 +155,10 @@ exports.removeStorage = removeStorage;
 var getStorage = function (key) {
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    return localStorage.getItem(key);
+    var value = localStorage.getItem(removeKeyBuilder(key));
+    if (!value)
+        return value;
+    return parseValueToGetStorage(value);
 };
 exports.getStorage = getStorage;
 /**

--- a/lib/esm/index.d.ts
+++ b/lib/esm/index.d.ts
@@ -10,8 +10,8 @@ declare type DependencyList = string[];
 declare type UseEffectReturn = ReturnType<typeof useEffect>;
 declare const useEffectStorageListener: (callback: EffectCallback | EffectCallbackWithParameters, dependencies: DependencyList) => UseEffectReturn;
 export declare const useLocalStorage: (key: string) => {
-    state: string | null;
-    setState: import("react").Dispatch<import("react").SetStateAction<string | null>>;
+    state: any;
+    setState: import("react").Dispatch<any>;
 };
 /**
  * @param key

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -1,7 +1,16 @@
 import { useEffect, useState } from "react";
+var StoreTypes;
+(function (StoreTypes) {
+    StoreTypes["primitive"] = "usl_primitive";
+    StoreTypes["object"] = "usl_object";
+    StoreTypes["undefined"] = "usl_undefined";
+})(StoreTypes || (StoreTypes = {}));
 var eventsNamespace = "useStorageListener_";
 var keyBuilder = function (key) {
     return "" + eventsNamespace + key;
+};
+var removeKeyBuilder = function (key) {
+    return key.replace(eventsNamespace, "");
 };
 var useEffectStorageListener = function (callback, dependencies) {
     useEffect(function () {
@@ -16,7 +25,7 @@ var useEffectStorageListener = function (callback, dependencies) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     var storageWatcher = function (e) {
-        callback({ key: e.type, value: getStorage(e.type) });
+        callback({ key: removeKeyBuilder(e.type), value: getStorage(e.type) });
     };
 };
 export var useLocalStorage = function (key) {
@@ -60,18 +69,68 @@ export var useLocalStorage = function (key) {
 var eventDispatcher = function (key) {
     return window.dispatchEvent(new Event(keyBuilder(key), { bubbles: true, cancelable: true }));
 };
+/**
+ * @param value
+ * @returns
+ */
+var isPrimitive = function (value) {
+    return value == null || /^[sbn]/.test(typeof value);
+};
+/**
+ * @param value
+ * @returns
+ */
+var detectValueType = function (value) {
+    if (!value)
+        return StoreTypes.undefined;
+    if (isPrimitive(value)) {
+        return StoreTypes.primitive;
+    }
+    if (Array.isArray(value) || typeof value === "object") {
+        return StoreTypes.object;
+    }
+    return StoreTypes.undefined;
+};
+/**
+ * @param type
+ * @param value
+ * @returns
+ */
+var prefixBuilder = function (type, value) {
+    return value + "?" + eventsNamespace + "type=" + type;
+};
+/**
+ * @param value
+ * @returns
+ */
+var parseValueToSetStorage = function (value) {
+    var type = detectValueType(value);
+    if (type === StoreTypes.undefined)
+        return null;
+    var parseValue = type === StoreTypes.object ? JSON.stringify(value) : value;
+    return prefixBuilder(type, parseValue);
+};
+var parseValueToGetStorage = function (value) {
+    var nonParseData = value.split("?useStorageListener_type=");
+    switch (nonParseData[1]) {
+        case StoreTypes.object:
+            return JSON.parse(nonParseData[0]);
+        default:
+            return nonParseData[0];
+    }
+};
 // Local storage methods
 /**
  * @param key
  * @param arg
  */
 export var setStorage = function (key, arg) {
+    var value = parseValueToSetStorage(arg);
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    if (!arg)
-        throw new Error("The storage events should not be used with no arguments");
-    var value = typeof arg === "string" ? arg : JSON.stringify(arg);
-    localStorage.setItem(key, value);
+    if (!value)
+        throw new Error("The storage events should not be used with null, undefined or no arguments ");
+    localStorage.setItem(removeKeyBuilder(key), value);
     eventDispatcher(key);
 };
 /**
@@ -80,7 +139,7 @@ export var setStorage = function (key, arg) {
 export var removeStorage = function (key) {
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    localStorage.removeItem(key);
+    localStorage.removeItem(removeKeyBuilder(key));
     eventDispatcher(key);
 };
 /**
@@ -90,7 +149,10 @@ export var removeStorage = function (key) {
 export var getStorage = function (key) {
     if (!key)
         throw new Error("The storage events should not be used with no key");
-    return localStorage.getItem(key);
+    var value = localStorage.getItem(removeKeyBuilder(key));
+    if (!value)
+        return value;
+    return parseValueToGetStorage(value);
 };
 /**
  * @param callEventKey

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-storage-listener",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Controls the local storage from any file or as a react state",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ const useEffectStorageListener = (
 };
 
 export const useLocalStorage = (key: string) => {
-  const [state, setState] = useState<null | string>(null);
+  const [state, setState] = useState<null | any>(null);
 
   useEffect(() => {
     setState(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,7 @@ const useEffectStorageListener = (
   }, []);
 
   const storageWatcher = (e: any) => {
-    callback({ key: e.type, value: getStorage(e.type) });
+    callback({ key: removeKeyBuilder(e.type), value: getStorage(e.type) });
   };
 };
 
@@ -155,7 +155,7 @@ export const setStorage = (key: string, arg: unknown) => {
     throw new Error(
       "The storage events should not be used with null, undefined or no arguments "
     );
-  localStorage.setItem(key, value);
+  localStorage.setItem(removeKeyBuilder(key), value);
   eventDispatcher(key);
 };
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,11 +7,17 @@ type EffectCallbackWithParameters = (data: DataEffectParameters) => void;
 type DependencyList = string[];
 type UseEffectReturn = ReturnType<typeof useEffect>;
 
+enum StoreTypes {
+  primitive = "USL_PRIMITIVE",
+  object = "USL_OBJECT",
+  undefined = "USL_UNDEFINED",
+}
+
 const eventsNamespace = "useStorageListener_";
 
 const keyBuilder = (key: string) => {
   return `${eventsNamespace}${key}`;
-}
+};
 
 const useEffectStorageListener = (
   callback: EffectCallback | EffectCallbackWithParameters,
@@ -28,7 +34,7 @@ const useEffectStorageListener = (
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  
+
   const storageWatcher = (e: any) => {
     callback({ key: e.type, value: getStorage(e.type) });
   };
@@ -46,10 +52,10 @@ export const useLocalStorage = (key: string) => {
   }, []);
 
   useEffect(() => {
-    if (state){ 
+    if (state) {
       setStorage(key, state);
-    }else {
-      removeStorage(key)
+    } else {
+      removeStorage(key);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -82,18 +88,65 @@ const eventDispatcher = (key: string) => {
     new Event(keyBuilder(key), { bubbles: true, cancelable: true })
   );
 };
+/**
+ * @param value
+ * @returns
+ */
+const isPrimitive = (value: unknown): boolean => {
+  return value == null || /^[sbn]/.test(typeof value);
+};
+/**
+ * @param value
+ * @returns
+ */
+const detectValueType = (value: unknown): StoreTypes => {
+  if (Array.isArray(value) || typeof value === "object") {
+    return StoreTypes.object;
+  }
+  if (isPrimitive(value)) {
+    return StoreTypes.primitive;
+  }
+  return StoreTypes.undefined;
+};
+/**
+ * @param type 
+ * @param value 
+ * @returns 
+ */
+const prefixBuilder = (type:StoreTypes, value: string ): string => {
+  return `${value}?${eventsNamespace}type=${type}`;
+} 
+/**
+ * @param value
+ * @returns
+ */
+const parseValueToSetStorage = (value: unknown): string | null => {
+  const type = detectValueType(value);
+  if(type === StoreTypes.undefined) return null;
+  return prefixBuilder(type, JSON.stringify(value))
+};
 
+const parseValueToGetStorage = (value: string) => {
+  const nonParseData = value.split('?useStorageListener_type=');
+  switch (nonParseData[1]) {
+    case StoreTypes.object:  
+      return JSON.parse(nonParseData[0])
+    default:
+      return nonParseData[0];
+  } 
+};
 // Local storage methods
 /**
  * @param key
  * @param arg
  */
 export const setStorage = (key: string, arg: unknown) => {
+  const value = parseValueToSetStorage(arg);
   if (!key)
     throw new Error("The storage events should not be used with no key");
-  if (!arg)
+  if (!value)
     throw new Error("The storage events should not be used with no arguments");
-  const value = typeof arg === "string" ? arg : JSON.stringify(arg);
+  //const value = typeof arg === "string" ? arg : JSON.stringify(arg);
   localStorage.setItem(key, value);
   eventDispatcher(key);
 };
@@ -113,7 +166,9 @@ export const removeStorage = (key: string) => {
 export const getStorage = (key: string): string | null => {
   if (!key)
     throw new Error("The storage events should not be used with no key");
-  return localStorage.getItem(key);
+  const value = localStorage.getItem(key)
+  if(!value) return value;
+  return parseValueToGetStorage(value);
 };
 /**
  * @param callEventKey


### PR DESCRIPTION
something that I find very interesting is to be able to capture the elements stored in the local storge with their original type, for a more flexible and fast manipulation. 

although it is a change that I want to test, basically I want to capture the type of the element either object or primitive and then save it together with the corresponding value using the space name of the passed feature. 

- Capture the type ( primitive or object )
- Transform the value into a string
- Join the value with the prefix of the type
`${value}?${spaceName}type=${type}`

Value saved:
`{ name: 'nicolas',  message:'hi everyone'}?useStorageListener_type=USL_OBJECT`
